### PR TITLE
Allow notifications to be forwarded to a debug endpoint.

### DIFF
--- a/lib/bnr/webhooks.rb
+++ b/lib/bnr/webhooks.rb
@@ -16,16 +16,24 @@ module Bnr
     Error = Class.new(::StandardError)
     DispatcherNotFound = Class.new(Error)
 
-    EVENT_HEADER     = 'X-BNR-Webhook-Event-Name'
-    SIGNATURE_HEADER = 'X-BNR-Webhook-Signature'
+    EVENT_HEADER       = 'X-BNR-Webhook-Event-Name'
+    SIGNATURE_HEADER   = 'X-BNR-Webhook-Signature'
+    DESTINATION_HEADER = 'X-BNR-Webhook-Original-Destination'
 
     mattr_accessor :api_key
-    @@api_key = 'fake_key'
+    mattr_accessor :debug_endpoint
 
     class << self
       def configure
         yield self
       end
+
+      def defaults!
+        @@api_key = 'fake_key'
+        @@debug_endpoint = false
+      end
     end
+
+    defaults!
   end
 end

--- a/lib/bnr/webhooks/notifier.rb
+++ b/lib/bnr/webhooks/notifier.rb
@@ -20,11 +20,11 @@ module Bnr
       end
 
       def notify
+        response = send_to(subscriber.url)
         send_to(debug_endpoint) do |request|
           request.headers[Bnr::Webhooks::DESTINATION_HEADER] = subscriber.url
         end if debug_endpoint?
-
-        send_to(subscriber.url)
+        response
       end
 
       private

--- a/lib/bnr/webhooks/notifier.rb
+++ b/lib/bnr/webhooks/notifier.rb
@@ -20,16 +20,34 @@ module Bnr
       end
 
       def notify
+        send_to(debug_endpoint) do |request|
+          request.headers[Bnr::Webhooks::DESTINATION_HEADER] = subscriber.url
+        end if debug_endpoint?
+
+        send_to(subscriber.url)
+      end
+
+      private
+
+      def send_to(url)
         http_client.post do |request|
-          request.url subscriber.url
+          request.url url
           request.headers['Content-Type'] = 'application/json'
           request.headers[Bnr::Webhooks::EVENT_HEADER] = event
           request.headers[Bnr::Webhooks::SIGNATURE_HEADER] = signature
           request.body = body
+
+          yield(request) if block_given?
         end
       end
 
-      private
+      def debug_endpoint
+        Bnr::Webhooks.debug_endpoint
+      end
+
+      def debug_endpoint?
+        debug_endpoint.present?
+      end
 
       def body
         source.to_json

--- a/spec/bnr/webhooks_spec.rb
+++ b/spec/bnr/webhooks_spec.rb
@@ -4,14 +4,17 @@ describe Bnr::Webhooks do
   context '#configure' do
     it 'has reasonable defaults' do
       expect(described_class.api_key).to eql('fake_key')
+      expect(described_class.debug_endpoint).to eql(false)
     end
 
     it 'can override defaults' do
       described_class.configure do |config|
         config.api_key = 'super_secret'
+        config.debug_endpoint = 'http://example.com/monitor'
       end
 
       expect(described_class.api_key).to eql('super_secret')
+      expect(described_class.debug_endpoint).to eql('http://example.com/monitor')
     end
   end
 end


### PR DESCRIPTION
Super basic monitoring. All outgoing webhooks will be forwarded to a debugging endpoint, along with an extra header indicating the original destination.

@srbiv :eyes: